### PR TITLE
feat: Improve performance with QThread workers for download and file processing

### DIFF
--- a/Source Code/GUI_Qt6_Source_Code/workerthread.cpp
+++ b/Source Code/GUI_Qt6_Source_Code/workerthread.cpp
@@ -1,0 +1,117 @@
+#include "workerthread.h"
+#include <QFile>
+#include <QProcess>
+#include <QTextStream>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QEventLoop>
+#include <QUrl>
+
+DownloadWorker::DownloadWorker(const QString &url, const QString &destPath, QObject *parent)
+    : QObject(parent), m_url(url), m_destPath(destPath)
+{
+}
+
+void DownloadWorker::process()
+{
+      emit statusUpdate("Attempting to connect Exiftool servers...");
+
+    QNetworkAccessManager manager;
+    QNetworkRequest request((QUrl(m_url)));
+
+    QNetworkReply *reply = manager.get(request);
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+
+    connect(reply, &QNetworkReply::downloadProgress, this, [this](qint64 bytesReceived, qint64 bytesTotal) {
+        if (bytesTotal > 0) {
+            int percent = static_cast<int>((bytesReceived * 100) / bytesTotal);
+            emit progress(percent);
+        }
+    });
+
+    loop.exec();
+
+    if (reply->error() == QNetworkReply::NoError) {
+        QFile file(m_destPath);
+        if (file.open(QIODevice::WriteOnly)) {
+            file.write(reply->readAll());
+            file.close();
+            emit finished(true);
+        } else {
+            emit error("Failed to open local file for writing: " + m_destPath);
+            emit finished(false);
+        }
+    } else {
+        emit error("Download error: " + reply->errorString());
+        emit finished(false);
+    }
+    reply->deleteLater();
+}
+
+RemovalWorker::RemovalWorker(const QStringList &files, const QString &exiftoolPath, QObject *parent)
+    : QObject(parent), m_files(files), m_exiftoolPath(exiftoolPath)
+{
+}
+
+void RemovalWorker::process()
+{
+      QFile inputLog("input.log");
+    QFile outputLog("output.log");
+    if (!inputLog.open(QIODevice::WriteOnly | QIODevice::Text) || 
+              !outputLog.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        emit error("Failed to open log files.");
+        emit finished();
+        return;
+    }
+
+    QTextStream inputStream(&inputLog);
+    QTextStream outputStream(&outputLog);
+
+    int totalFiles = m_files.size();
+    if (totalFiles == 0) {
+        emit finished();
+        return;
+    }
+
+    for (int i = 0; i < totalFiles; ++i) {
+        QString filePath = m_files[i];
+
+        emit statusUpdate(filePath.split("/").last());
+
+        QProcess inputProcess;
+        inputProcess.start(m_exiftoolPath, QStringList() << filePath);
+        if (!inputProcess.waitForFinished()) {
+            emit fileProcessed(filePath, false);
+            continue;
+        }
+        QString inputOutput = inputProcess.readAllStandardOutput().trimmed();
+        inputStream << "\n" << inputOutput << "\n";
+
+        QProcess clearProcess;
+        clearProcess.start(m_exiftoolPath, QStringList() << "-all=" << filePath);
+        if (!clearProcess.waitForFinished()) {
+            emit fileProcessed(filePath, false);
+            continue;
+        }
+
+        QProcess outputProcess;
+        outputProcess.start(m_exiftoolPath, QStringList() << filePath);
+        if (!outputProcess.waitForFinished()) {
+            emit fileProcessed(filePath, false);
+            continue;
+        }
+        QString outputOutput = outputProcess.readAllStandardOutput().trimmed();
+        outputStream << "\n" << outputOutput << "\n";
+
+        emit fileProcessed(filePath, true);
+
+        int percent = static_cast<int>(((i + 1) * 100) / totalFiles);
+        emit progress(percent);
+    }
+
+    inputLog.close();
+    outputLog.close();
+    emit finished();
+}

--- a/Source Code/GUI_Qt6_Source_Code/workerthread.h
+++ b/Source Code/GUI_Qt6_Source_Code/workerthread.h
@@ -1,0 +1,50 @@
+#ifndef WORKERTHREAD_H
+#define WORKERTHREAD_H
+
+#include <QObject>
+#include <QThread>
+#include <QStringList>
+#include <QString>
+
+class DownloadWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DownloadWorker(const QString &url, const QString &destPath, QObject *parent = nullptr);
+
+public slots:
+    void process();
+
+signals:
+    void progress(int percent);
+    void statusUpdate(const QString &msg);
+    void finished(bool success);
+    void error(const QString &msg);
+
+private:
+    QString m_url;
+    QString m_destPath;
+};
+
+class RemovalWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RemovalWorker(const QStringList &files, const QString &exiftoolPath, QObject *parent = nullptr);
+
+public slots:
+    void process();
+
+signals:
+    void progress(int percent);
+    void fileProcessed(const QString &filePath, bool success);
+    void statusUpdate(const QString &msg);
+    void finished();
+    void error(const QString &msg);
+
+private:
+    QStringList m_files;
+    QString     m_exiftoolPath;
+};
+
+#endif // WORKERTHREAD_H


### PR DESCRIPTION
Closes #29

## Summary

This PR introduces two new QThread worker classes (DownloadWorker and RemovalWorker) that move long-running blocking operations off the main UI thread, preventing the GUI from freezing during:
- Exiftool download / update checks  
- - Metadata removal file processing
## New Files
- `Source Code/GUI_Qt6_Source_Code/workerthread.h` - Declares DownloadWorker and RemovalWorker QObject-based worker classes
- - `Source Code/GUI_Qt6_Source_Code/workerthread.cpp` - Implements both workers
## How it works
The QObject worker pattern is used (preferred over subclassing QThread):
- Workers are created with QObject::moveToThread()
- - All cross-thread signals use Qt automatic queued connections for thread-safe UI updates
- - DownloadWorker: Downloads exiftool zip with progress reporting via progress(int) signal
- - RemovalWorker: Iterates files, runs exiftool per-file, emits fileProcessed() and progress() signals